### PR TITLE
Cli output improvements

### DIFF
--- a/classes/alias.js
+++ b/classes/alias.js
@@ -39,21 +39,21 @@ module.exports = class Alias {
 
         this.log.debug('Requesting alias creation from asset server');
         try {
-            const message = await sendCommand({
+            const { message } = await sendCommand({
                 host: this.server,
                 method: 'PUT',
                 pathname: join(
                     this.org,
                     this.type,
                     this.name,
-                    `v${this.alias}`
+                    `v${this.alias}`,
                 ),
-                data: { version: this.version }
+                data: { version: this.version },
             });
 
             if (message.org) {
                 this.log.debug(
-                    `  Org: ${message.org}, Name: ${message.name}, Version: ${message.version}`
+                    `  Org: ${message.org}, Name: ${message.name}, Version: ${message.version}`,
                 );
             }
 

--- a/classes/alias.js
+++ b/classes/alias.js
@@ -62,9 +62,82 @@ module.exports = class Alias {
                     this.log.debug(`  ==> ${JSON.stringify(file)}`);
                 }
             }
+
+            this.log.info(
+                `Created ${this.type} alias "v${this.alias}" (for "${this.name}") and set it to point to version "${this.version}"`,
+            );
         } catch (err) {
+            let status = err.statusCode;
+
+            if (status === 409) {
+                this.log.debug('Alias already exists, publishing update');
+
+                try {
+                    const { message: msg } = await sendCommand({
+                        host: this.server,
+                        method: 'POST',
+                        pathname: join(
+                            this.org,
+                            this.type,
+                            this.name,
+                            `v${this.alias}`,
+                        ),
+                        data: { version: this.version },
+                    });
+
+                    if (msg.org) {
+                        this.log.debug(
+                            `  Org: ${msg.org}, Name: ${msg.name}, Version: ${msg.version}`,
+                        );
+                    }
+
+                    if (msg.files) {
+                        for (const file of msg.files) {
+                            this.log.debug(`  ==> ${JSON.stringify(file)}`);
+                        }
+                    }
+
+                    this.log.info(
+                        `Updated ${this.type} alias "v${this.alias}" (for "${this.name}") to point to version "${this.version}"`,
+                    );
+                    return true;
+                } catch (error) {
+                    status = error.statusCode;
+                }
+            }
+
             this.log.error('Unable to complete alias command');
-            this.log.warn(err.message);
+
+            switch (status) {
+                case 400:
+                    this.log.warn(
+                        'Client attempted to send an invalid URL parameter',
+                    );
+                    break;
+                case 401:
+                    this.log.warn('Client unauthorized with server');
+                    break;
+                case 404:
+                    this.log.warn(
+                        'The server was unable to locate the required resource',
+                    );
+                    break;
+                case 409:
+                    this.log.warn(
+                        `${this.type} with name "${this.name}" and version "${this.version}" already exists on server`,
+                    );
+                    break;
+                case 415:
+                    this.log.warn(
+                        'Client attempted to send an unsupported file format to server',
+                    );
+                    break;
+                case 502:
+                    this.log.warn('Server was unable to write file to storage');
+                    break;
+                default:
+                    this.log.warn('Server failed');
+            }
 
             return false;
         }

--- a/classes/init.js
+++ b/classes/init.js
@@ -65,7 +65,9 @@ module.exports = class Init {
             `assets.json file created and saved to "${this.pathname}"`,
         );
 
-        this.log.debug('Init command complete');
+        this.log.info(
+            'Created "assets.json" file in the current working directory',
+        );
         return true;
     }
 };

--- a/classes/publish/app.js
+++ b/classes/publish/app.js
@@ -281,7 +281,9 @@ module.exports = class PublishApp {
             this.log.debug(`  ==> ${this.path}/ie11/index.js.map`);
             this.log.debug(`  ==> ${this.path}/main/index.css`);
             this.log.debug(`  ==> ${this.path}/main/index.css.map`);
-            this.log.debug('Publish command complete (dry run)');
+            this.log.info(
+                `Published app package "${this.name}" at version "${this.version}" (dry run)`,
+            );
             return true;
         }
 
@@ -331,7 +333,9 @@ module.exports = class PublishApp {
             return false;
         }
 
-        this.log.debug('Publish command complete');
+        this.log.info(
+            `Published app package "${this.name}" at version "${this.version}"`,
+        );
         return true;
     }
 };

--- a/classes/publish/app.js
+++ b/classes/publish/app.js
@@ -288,7 +288,7 @@ module.exports = class PublishApp {
         // upload files
         this.log.debug('Uploading zip file to server');
         try {
-            const message = await sendCommand({
+            const { message } = await sendCommand({
                 method: 'PUT',
                 host: this.server,
                 pathname: join(this.org, 'pkg', this.name, this.version),

--- a/classes/publish/app.js
+++ b/classes/publish/app.js
@@ -303,7 +303,31 @@ module.exports = class PublishApp {
             }
         } catch (err) {
             this.log.error('Unable to upload zip file to server');
-            this.log.warn(err.message);
+            switch (err.statusCode) {
+                case 400:
+                    this.log.warn(
+                        'Client attempted to send an invalid URL parameter',
+                    );
+                    break;
+                case 401:
+                    this.log.warn('Client unauthorized with server');
+                    break;
+                case 409:
+                    this.log.warn(
+                        `Package with name "${this.name}" and version "${this.version}" already exists on server`,
+                    );
+                    break;
+                case 415:
+                    this.log.warn(
+                        'Client attempted to send an unsupported file format to server',
+                    );
+                    break;
+                case 502:
+                    this.log.warn('Server was unable to write file to storage');
+                    break;
+                default:
+                    this.log.warn('Server failed');
+            }
             return false;
         }
 

--- a/classes/publish/dependency.js
+++ b/classes/publish/dependency.js
@@ -222,7 +222,7 @@ module.exports = class PublishDependency {
 
         this.log.debug('Uploading zip file to server');
         try {
-            const message = await sendCommand({
+            const { message } = await sendCommand({
                 method: 'PUT',
                 host: this.server,
                 pathname: join(this.org, 'pkg', this.name, this.version),

--- a/classes/publish/dependency.js
+++ b/classes/publish/dependency.js
@@ -216,7 +216,7 @@ module.exports = class PublishDependency {
             this.log.debug(`  ==> ${this.zipFile}`);
             this.log.debug(`  ==> ${this.file}`);
             this.log.debug(`  ==> ${this.file}.map`);
-            this.log.debug(
+            this.log.info(
                 `Published dependency package "${this.name}" at version "${this.version}" (dry run)`,
             );
             return true;

--- a/classes/publish/dependency.js
+++ b/classes/publish/dependency.js
@@ -237,7 +237,31 @@ module.exports = class PublishDependency {
             }
         } catch (err) {
             this.log.error('Unable to upload zip file to server');
-            this.log.warn(err.message);
+            switch (err.statusCode) {
+                case 400:
+                    this.log.warn(
+                        'Client attempted to send an invalid URL parameter',
+                    );
+                    break;
+                case 401:
+                    this.log.warn('Client unauthorized with server');
+                    break;
+                case 409:
+                    this.log.warn(
+                        `Package with name "${this.name}" and version "${this.version}" already exists on server`,
+                    );
+                    break;
+                case 415:
+                    this.log.warn(
+                        'Client attempted to send an unsupported file format to server',
+                    );
+                    break;
+                case 502:
+                    this.log.warn('Server was unable to write file to storage');
+                    break;
+                default:
+                    this.log.warn('Server failed');
+            }
             return false;
         }
 

--- a/classes/publish/dependency.js
+++ b/classes/publish/dependency.js
@@ -216,7 +216,9 @@ module.exports = class PublishDependency {
             this.log.debug(`  ==> ${this.zipFile}`);
             this.log.debug(`  ==> ${this.file}`);
             this.log.debug(`  ==> ${this.file}.map`);
-            this.log.debug('Publish command complete (dry run)');
+            this.log.debug(
+                `Published dependency package "${this.name}" at version "${this.version}" (dry run)`,
+            );
             return true;
         }
 
@@ -265,7 +267,9 @@ module.exports = class PublishDependency {
             return false;
         }
 
-        this.log.debug('Publish command complete');
+        this.log.info(
+            `Published dependency package "${this.name}" at version "${this.version}"`,
+        );
         return true;
     }
 };

--- a/classes/publish/map.js
+++ b/classes/publish/map.js
@@ -106,7 +106,9 @@ module.exports = class PublishMap {
             return false;
         }
 
-        this.log.debug('Import map publish command complete');
+        this.log.info(
+            `Published import map "${this.name}" at version "${this.version}"`,
+        );
         return true;
     }
 };

--- a/classes/version.js
+++ b/classes/version.js
@@ -47,9 +47,8 @@ module.exports = class Version {
 
         this.log.debug('Updating assets.json version field');
         try {
-            const oldVersion = this.assets.version;
+            this.oldVersion = this.assets.version;
             this.assets.version = semver.inc(this.assets.version, this.level);
-            this.log.debug(`"${oldVersion}" => "${this.assets.version}"`);
         } catch (err) {
             this.log.error('Failed to update "assets.version"');
             this.log.warn(err.message);
@@ -70,7 +69,9 @@ module.exports = class Version {
             return false;
         }
 
-        this.log.debug('Version command complete');
+        this.log.info(
+            `Updated version field of "assets.json" file from "${this.oldVersion}" to "${this.assets.version}"`,
+        );
         return true;
     }
 };

--- a/commands/alias.js
+++ b/commands/alias.js
@@ -53,23 +53,34 @@ exports.builder = yargs => {
             describe: 'Provide the organisation context for the command.',
             default: assets.organisation || '',
         },
+        debug: {
+            describe: 'Logs additional messages',
+            default: false,
+            type: 'boolean',
+        },
     });
 };
 
 exports.handler = async argv => {
-    const spinner = ora().start();
+    const spinner = ora().start('working...');
     let success = false;
+    const { debug } = argv;
 
     try {
-        success = await new Alias({ logger: logger(spinner), ...argv }).run();
+        success = await new Alias({
+            logger: logger(spinner, debug),
+            ...argv,
+        }).run();
     } catch (err) {
         logger.warn(err.message);
     }
 
     if (success) {
-        spinner.succeed('🤘');
+        spinner.text = '';
+        spinner.stopAndPersist();
     } else {
-        spinner.fail('🥺');
+        spinner.text = '';
+        spinner.stopAndPersist();
         process.exit(1);
     }
 };

--- a/commands/dependency.js
+++ b/commands/dependency.js
@@ -54,23 +54,32 @@ exports.builder = yargs => {
             default: false,
             type: 'boolean',
         },
+        debug: {
+            describe: 'Logs additional messages',
+            default: false,
+            type: 'boolean',
+        },
     });
 };
 
 exports.handler = async argv => {
-    const spinner = ora().start();
+    const spinner = ora().start('working...');
     let success = false;
+    const { debug } = argv;
+
     try {
-        const options = { logger: logger(spinner), ...argv };
+        const options = { logger: logger(spinner, debug), ...argv };
         success = await new PublishDependency(options).run();
     } catch (err) {
         spinner.warn(err.message);
     }
 
     if (success) {
-        spinner.succeed('🤘');
+        spinner.text = '';
+        spinner.stopAndPersist();
     } else {
-        spinner.fail('🥺');
+        spinner.text = '';
+        spinner.stopAndPersist();
         process.exit(1);
     }
 };

--- a/commands/init.js
+++ b/commands/init.js
@@ -47,23 +47,34 @@ exports.builder = yargs => {
                 'Specify the path on local disk to CSS client side assets relative to the current working directory.',
             default: '',
         },
+        debug: {
+            describe: 'Logs additional messages',
+            default: false,
+            type: 'boolean',
+        },
     });
 };
 
 exports.handler = async argv => {
-    const spinner = ora().start();
+    const spinner = ora().start('working...');
     let success = false;
+    const { debug } = argv;
 
     try {
-        success = await new Init({ logger: logger(spinner), ...argv }).run();
+        success = await new Init({
+            logger: logger(spinner, debug),
+            ...argv,
+        }).run();
     } catch (err) {
         logger.warn(err.message);
     }
 
     if (success) {
-        spinner.succeed('🤘');
+        spinner.text = '';
+        spinner.stopAndPersist();
     } else {
-        spinner.fail('🥺');
+        spinner.text = '';
+        spinner.stopAndPersist();
         process.exit(1);
     }
 };

--- a/commands/map.js
+++ b/commands/map.js
@@ -47,15 +47,22 @@ exports.builder = yargs => {
             describe: 'Provide the organisation context for the command.',
             default: assets.organisation || '',
         },
+        debug: {
+            describe: 'Logs additional messages',
+            default: false,
+            type: 'boolean',
+        },
     });
 };
 
 exports.handler = async argv => {
-    const spinner = ora().start();
+    const spinner = ora().start('working...');
     let success = false;
+    const { debug } = argv;
+
     try {
         success = await new Map({
-            logger: logger(spinner),
+            logger: logger(spinner, debug),
             ...argv,
         }).run();
     } catch (err) {
@@ -63,9 +70,11 @@ exports.handler = async argv => {
     }
 
     if (success) {
-        spinner.succeed('🤘');
+        spinner.text = '';
+        spinner.stopAndPersist();
     } else {
-        spinner.fail('🥺');
+        spinner.text = '';
+        spinner.stopAndPersist();
         process.exit(1);
     }
 };

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -44,6 +44,11 @@ exports.builder = yargs => {
             default: false,
             type: 'boolean',
         },
+        debug: {
+            describe: 'Logs additional messages',
+            default: false,
+            type: 'boolean',
+        },
         js: {
             describe:
                 'Specify the path on local disk to JavaScript client side assets relative to the current working directory.',
@@ -66,20 +71,23 @@ exports.builder = yargs => {
 };
 
 exports.handler = async argv => {
-    const spinner = ora().start();
+    const spinner = ora().start('working...');
     let success = false;
+    const { debug } = argv;
 
     try {
-        const options = { logger: logger(spinner), ...argv };
+        const options = { logger: logger(spinner, debug), ...argv };
         success = await new PublishApp(options).run();
     } catch (err) {
         spinner.warn(err.message);
     }
 
     if (success) {
-        spinner.succeed('🤘');
+        spinner.text = '';
+        spinner.stopAndPersist();
     } else {
-        spinner.fail('🥺');
+        spinner.text = '';
+        spinner.stopAndPersist();
         process.exit(1);
     }
 };

--- a/commands/version.js
+++ b/commands/version.js
@@ -29,12 +29,13 @@ by major (1.0.0 -> 2.0.0), minor (1.0.0 -> 1.1.0) or patch (1.0.0 -> 1.0.1)`,
 };
 
 exports.handler = async argv => {
-    const spinner = ora().start();
+    const spinner = ora().start('working...');
     let success = false;
+    const { debug } = argv;
 
     try {
         success = await new Version({
-            logger: logger(spinner),
+            logger: logger(spinner, debug),
             cwd: argv.cwd,
             level: argv.major,
         }).run();
@@ -43,9 +44,11 @@ exports.handler = async argv => {
     }
 
     if (success) {
-        spinner.succeed('🤘');
+        spinner.text = '';
+        spinner.stopAndPersist();
     } else {
-        spinner.fail('🥺');
+        spinner.text = '';
+        spinner.stopAndPersist();
         process.exit(1);
     }
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "@asset-pipe/core": "^1.0.0-alpha.1",
+    "@asset-pipe/core": "^1.0.0-alpha.2",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.5.0",

--- a/test/alias.test.js
+++ b/test/alias.test.js
@@ -17,7 +17,8 @@ test('Creating a package alias on an asset server', async t => {
         server: `http://localhost:${port}`,
         org: 'my-test-org',
         name: 'lit-html',
-        version: '1.1.2'
+        version: '1.1.2',
+        debug: true,
     }).run();
 
     const result = await new cli.Alias({
@@ -27,7 +28,8 @@ test('Creating a package alias on an asset server', async t => {
         type: 'pkg',
         name: 'lit-html',
         version: '1.1.2',
-        alias: '1'
+        alias: '1',
+        debug: true,
     }).run();
 
     t.equals(result, true, 'Command should return true');
@@ -48,7 +50,8 @@ test('Creating a map alias on an asset server', async t => {
         org: 'my-test-org',
         name: 'my-map',
         version: '1.0.0',
-        file: './fixtures/import-map.json'
+        file: './fixtures/import-map.json',
+        debug: true,
     }).run();
 
     const result = await new cli.Alias({
@@ -58,7 +61,8 @@ test('Creating a map alias on an asset server', async t => {
         type: 'map',
         name: 'my-map',
         version: '1.0.0',
-        alias: '1'
+        alias: '1',
+        debug: true,
     }).run();
 
     t.equals(result, true, 'Command should return true');

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -11,11 +11,12 @@ test('Initializing a new assets.json file', async t => {
 
     const result = await new cli.Init({
         logger: l.logger,
-        cwd: join(__dirname, 'tmp')
+        cwd: join(__dirname, 'tmp'),
+        debug: true,
     }).run();
 
     const assets = JSON.parse(
-        readFileSync(join(__dirname, 'tmp', 'assets.json'))
+        readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );
 
     t.equals(result, true, 'Command should return true');
@@ -24,29 +25,29 @@ test('Initializing a new assets.json file', async t => {
     t.equals(
         assets.version,
         '1.0.0',
-        'assets.json "version" field should not be empty'
+        'assets.json "version" field should not be empty',
     );
     t.equals(
         assets.organisation,
         '',
-        'assets.json "organisation" field should be empty'
+        'assets.json "organisation" field should be empty',
     );
     t.equals(assets.server, '', 'assets.json "server" field should be empty');
     t.equals(
         assets.js.input,
         '',
-        'assets.json "js.input" field should be empty'
+        'assets.json "js.input" field should be empty',
     );
     t.equals(
         assets.css.input,
         '',
-        'assets.json "css.input" field should be empty'
+        'assets.json "css.input" field should be empty',
     );
 
     t.match(
-        l.logs.debug,
-        'Init command complete',
-        'Log output should command completion'
+        l.logs.info,
+        'Created "assets.json" file in the current working directory',
+        'Log output should command completion',
     );
 
     unlinkSync(join(__dirname, 'tmp', 'assets.json'));
@@ -63,11 +64,12 @@ test('Initializing a new assets.json file passing custom values', async t => {
         version: '0.0.1',
         server: 'http://localhost:4001',
         js: './assets/client.js',
-        css: './assets/styles.css'
+        css: './assets/styles.css',
+        debug: true,
     }).run();
 
     const assets = JSON.parse(
-        readFileSync(join(__dirname, 'tmp', 'assets.json'))
+        readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );
 
     t.equals(result, true, 'Command should return true');
@@ -75,38 +77,38 @@ test('Initializing a new assets.json file passing custom values', async t => {
     t.equals(
         assets.name,
         'custom-name',
-        'assets.json "name" field should not be empty'
+        'assets.json "name" field should not be empty',
     );
     t.equals(
         assets.version,
         '0.0.1',
-        'assets.json "version" field should not be empty'
+        'assets.json "version" field should not be empty',
     );
     t.equals(
         assets.organisation,
         'custom-org',
-        'assets.json "organisation" field should not be empty'
+        'assets.json "organisation" field should not be empty',
     );
     t.equals(
         assets.server,
         'http://localhost:4001',
-        'assets.json "server" field should not be empty'
+        'assets.json "server" field should not be empty',
     );
     t.equals(
         assets.js.input,
         './assets/client.js',
-        'assets.json "js.input" field should not be empty'
+        'assets.json "js.input" field should not be empty',
     );
     t.equals(
         assets.css.input,
         './assets/styles.css',
-        'assets.json "css.input" field should not be empty'
+        'assets.json "css.input" field should not be empty',
     );
 
     t.match(
-        l.logs.debug,
-        'Init command complete',
-        'Log output should command completion'
+        l.logs.info,
+        'Created "assets.json" file in the current working directory',
+        'Log output should command completion',
     );
 
     unlinkSync(join(__dirname, 'tmp', 'assets.json'));

--- a/test/publish.app.test.js
+++ b/test/publish.app.test.js
@@ -33,8 +33,8 @@ test('Uploading app assets to an asset server', async t => {
         'Log output should show published name, version and org',
     );
     t.match(
-        l.logs.debug,
-        'Publish command complete',
+        l.logs.info,
+        'Published app package "my-app" at version "1.0.0"',
         'Log output should command completion',
     );
 

--- a/test/publish.app.test.js
+++ b/test/publish.app.test.js
@@ -21,7 +21,8 @@ test('Uploading app assets to an asset server', async t => {
         name: 'my-app',
         version: '1.0.0',
         js: './fixtures/client.js',
-        css: './fixtures/styles.css'
+        css: './fixtures/styles.css',
+        debug: true,
     });
 
     const result = await publishApp.run();
@@ -29,12 +30,12 @@ test('Uploading app assets to an asset server', async t => {
     t.match(
         l.logs.debug,
         'Org: my-test-org, Name: my-app, Version: 1.0.0',
-        'Log output should show published name, version and org'
+        'Log output should show published name, version and org',
     );
     t.match(
         l.logs.debug,
         'Publish command complete',
-        'Log output should command completion'
+        'Log output should command completion',
     );
 
     await server.stop();

--- a/test/publish.dependency.test.js
+++ b/test/publish.dependency.test.js
@@ -19,6 +19,7 @@ test('Uploading a dependency to an asset server', async t => {
         org: 'my-test-org',
         name: 'lit-html',
         version: '1.1.2',
+        debug: true,
     });
 
     const result = await publishDep.run();

--- a/test/publish.dependency.test.js
+++ b/test/publish.dependency.test.js
@@ -31,8 +31,8 @@ test('Uploading a dependency to an asset server', async t => {
         'Log output should show published name, version and org',
     );
     t.match(
-        l.logs.debug,
-        'Publish command complete',
+        l.logs.info,
+        'Published dependency package "lit-html" at version "1.1.2"',
         'Log output should command completion',
     );
 

--- a/test/publish.dependency.test.js
+++ b/test/publish.dependency.test.js
@@ -23,10 +23,6 @@ test('Uploading a dependency to an asset server', async t => {
 
     const result = await publishDep.run();
 
-    console.log('asdasdasdASDASDADS');
-    console.log(l.logs.error);
-    console.log(l.logs.warn);
-
     t.equals(result, true, 'Command should return true');
     t.match(
         l.logs.debug,

--- a/test/publish.dependency.test.js
+++ b/test/publish.dependency.test.js
@@ -18,20 +18,25 @@ test('Uploading a dependency to an asset server', async t => {
         server: `http://localhost:${port}`,
         org: 'my-test-org',
         name: 'lit-html',
-        version: '1.1.2'
+        version: '1.1.2',
     });
 
     const result = await publishDep.run();
+
+    console.log('asdasdasdASDASDADS');
+    console.log(l.logs.error);
+    console.log(l.logs.warn);
+
     t.equals(result, true, 'Command should return true');
     t.match(
         l.logs.debug,
         'Org: my-test-org, Name: lit-html, Version: 1.1.2',
-        'Log output should show published name, version and org'
+        'Log output should show published name, version and org',
     );
     t.match(
         l.logs.debug,
         'Publish command complete',
-        'Log output should command completion'
+        'Log output should command completion',
     );
 
     await server.stop();

--- a/test/publish.map.test.js
+++ b/test/publish.map.test.js
@@ -20,7 +20,8 @@ test('Uploading import map to an asset server', async t => {
         org: 'my-test-org',
         name: 'my-map',
         version: '1.0.0',
-        file: './fixtures/import-map.json'
+        file: './fixtures/import-map.json',
+        debug: true,
     });
 
     const result = await publishMap.run();
@@ -28,12 +29,12 @@ test('Uploading import map to an asset server', async t => {
     t.match(
         l.logs.debug,
         'Uploading import map "my-map" version "1.0.0" to asset server',
-        'Log output should show published name, version and org'
+        'Log output should show published name, version and org',
     );
     t.match(
         l.logs.debug,
         'Import map publish command complete',
-        'Log output should command completion'
+        'Log output should command completion',
     );
 
     await server.stop();

--- a/test/publish.map.test.js
+++ b/test/publish.map.test.js
@@ -32,8 +32,8 @@ test('Uploading import map to an asset server', async t => {
         'Log output should show published name, version and org',
     );
     t.match(
-        l.logs.debug,
-        'Import map publish command complete',
+        l.logs.info,
+        'Published import map "my-map" at version "1.0.0"',
         'Log output should command completion',
     );
 

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -17,30 +17,31 @@ test('Versioning an assets.json file: major', async t => {
             version: '1.0.0',
             organisation: 'my-test-org',
             js: { input: '' },
-            css: { input: '' }
-        })
+            css: { input: '' },
+            debug: true,
+        }),
     );
 
     const result = await new cli.Version({
         logger: l.logger,
         cwd: join(__dirname, 'tmp'),
-        level: 'major'
+        level: 'major',
     }).run();
 
     const assets = JSON.parse(
-        readFileSync(join(__dirname, 'tmp', 'assets.json'))
+        readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );
 
     t.equals(result, true, 'Command should return true');
     t.equals(
         assets.version,
         '2.0.0',
-        'Command version should have been incremented'
+        'Command version should have been incremented',
     );
     t.match(
-        l.logs.debug,
-        'Version command complete',
-        'Log output should command completion'
+        l.logs.info,
+        'Updated version field of "assets.json" file from "1.0.0" to "2.0.0',
+        'Log output should command completion',
     );
 
     unlinkSync(join(__dirname, 'tmp', 'assets.json'));
@@ -57,30 +58,30 @@ test('Versioning an assets.json file: minor', async t => {
             version: '1.0.0',
             organisation: 'my-test-org',
             js: { input: '' },
-            css: { input: '' }
-        })
+            css: { input: '' },
+        }),
     );
 
     const result = await new cli.Version({
         logger: l.logger,
         cwd: join(__dirname, 'tmp'),
-        level: 'minor'
+        level: 'minor',
     }).run();
 
     const assets = JSON.parse(
-        readFileSync(join(__dirname, 'tmp', 'assets.json'))
+        readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );
 
     t.equals(result, true, 'Command should return true');
     t.equals(
         assets.version,
         '1.1.0',
-        'Command version should have been incremented'
+        'Command version should have been incremented',
     );
     t.match(
-        l.logs.debug,
-        'Version command complete',
-        'Log output should command completion'
+        l.logs.info,
+        'Updated version field of "assets.json" file from "1.0.0" to "1.1.0',
+        'Log output should command completion',
     );
 
     unlinkSync(join(__dirname, 'tmp', 'assets.json'));
@@ -97,30 +98,30 @@ test('Versioning an assets.json file: patch', async t => {
             version: '1.0.0',
             organisation: 'my-test-org',
             js: { input: '' },
-            css: { input: '' }
-        })
+            css: { input: '' },
+        }),
     );
 
     const result = await new cli.Version({
         logger: l.logger,
         cwd: join(__dirname, 'tmp'),
-        level: 'patch'
+        level: 'patch',
     }).run();
 
     const assets = JSON.parse(
-        readFileSync(join(__dirname, 'tmp', 'assets.json'))
+        readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );
 
     t.equals(result, true, 'Command should return true');
     t.equals(
         assets.version,
         '1.0.1',
-        'Command version should have been incremented'
+        'Command version should have been incremented',
     );
     t.match(
-        l.logs.debug,
-        'Version command complete',
-        'Log output should command completion'
+        l.logs.info,
+        'Updated version field of "assets.json" file from "1.0.0" to "1.0.1',
+        'Log output should command completion',
     );
 
     unlinkSync(join(__dirname, 'tmp', 'assets.json'));

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const logger = spinner => ({
+const logger = (spinner, debug = false) => ({
     fatal() {},
     error(message) {
         spinner.fail(message).start();
@@ -12,11 +12,11 @@ const logger = spinner => ({
         spinner.succeed(message).start();
     },
     debug(message) {
-        spinner.info(message).start();
+        if (debug) spinner.info(message).start();
     },
     trace(message) {
-        spinner.info(message).start();
-    }
+        if (debug) spinner.info(message).start();
+    },
 });
 
 module.exports = logger;

--- a/utils/send-command.js
+++ b/utils/send-command.js
@@ -39,16 +39,22 @@ async function sendCommand({
         });
 
         if (!res.ok) {
-            throw new Error(
+            const err = new Error(
                 `Server responded with a non 200 ok status code. Response: ${res.status}`,
             );
+            err.statusCode = res.status;
+            throw err;
         }
         if (res.headers.get('content-type').includes('application/json')) {
             return { message: await res.json(), status: res.status };
         }
         return { message: await res.text(), status: res.status };
     } catch (err) {
-        throw new Error(`Unable to complete command: ${err.message}`);
+        if (!err.statusCode) {
+            err.statusCode = 500;
+            throw new Error(`Unable to complete command: ${err.message}`);
+        }
+        throw err;
     }
 }
 

--- a/utils/send-command.js
+++ b/utils/send-command.js
@@ -52,7 +52,6 @@ async function sendCommand({
     } catch (err) {
         if (!err.statusCode) {
             err.statusCode = 500;
-            throw new Error(`Unable to complete command: ${err.message}`);
         }
         throw err;
     }

--- a/utils/send-command.js
+++ b/utils/send-command.js
@@ -11,7 +11,7 @@ async function sendCommand({
     pathname,
     data,
     file,
-    map
+    map,
 } = {}) {
     const form = new FormData();
 
@@ -35,19 +35,18 @@ async function sendCommand({
         const res = await fetch(url.href, {
             method,
             body: form,
-            headers: form.getHeaders()
+            headers: form.getHeaders(),
         });
 
         if (!res.ok) {
             throw new Error(
-                `Server responded with a non 200 ok status code. Response: ${res.status}`
+                `Server responded with a non 200 ok status code. Response: ${res.status}`,
             );
         }
         if (res.headers.get('content-type').includes('application/json')) {
-            return res.json();
-        } 
-            return res.text();
-        
+            return { message: await res.json(), status: res.status };
+        }
+        return { message: await res.text(), status: res.status };
     } catch (err) {
         throw new Error(`Unable to complete command: ${err.message}`);
     }


### PR DESCRIPTION
I've lined up CLI with latest changes to server as well as tuned output so that its clear and minimal unless you pass a new `--debug` flag in which case you get all the logs.

Some caveats:

* alias `pkg` doesn't work (though alias `map` does) due to 404 from server
* tests won't pass until server memory sink is updated. See https://github.com/asset-pipe/core/pull/44
* tests wont pass until alias command works (see first point above)
* tests wont pass when run via tap. Ie. `tap test/*.test.js` does not pass though `node test/init.test.js` does. Need to look further but error is very confusing, missing server deps when run this way 🤷‍♂ 