### PR TITLE
make temp dir more random and delete after use

### DIFF
--- a/classes/init.js
+++ b/classes/init.js
@@ -24,9 +24,6 @@ module.exports = class Init {
         this.server = server;
         this.js = { input: js, options: {} };
         this.css = { input: css, options: {} };
-
-        // eslint-disable-next-line no-console
-        console.log('resolved path:', this.pathname);
     }
 
     async run() {

--- a/classes/init.js
+++ b/classes/init.js
@@ -24,6 +24,9 @@ module.exports = class Init {
         this.server = server;
         this.js = { input: js, options: {} };
         this.css = { input: css, options: {} };
+
+        // eslint-disable-next-line no-console
+        console.log('resolved path:', this.pathname);
     }
 
     async run() {

--- a/classes/meta.js
+++ b/classes/meta.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const abslog = require('abslog');
+const { join } = require('path');
+const { validators } = require('@asset-pipe/common');
+const fetch = require('node-fetch');
+
+module.exports = class Meta {
+    constructor({ logger, server, org, name, version } = {}) {
+        this.log = abslog(logger);
+        this.server = server;
+        this.org = org;
+        this.name = name;
+        this.version = version;
+    }
+
+    async run() {
+        this.log.debug('Validating input');
+
+        try {
+            validators.origin(this.server);
+        } catch (err) {
+            this.log.error(`Parameter "server" is not valid`);
+            return false;
+        }
+
+        try {
+            validators.org(this.org);
+            validators.name(this.name);
+            validators.version(this.version);
+        } catch (err) {
+            this.log.error(err.message);
+            return false;
+        }
+
+        this.log.debug('Requesting meta information from asset server');
+        try {
+            const res = await fetch(
+                `${this.server}/${join(
+                    this.org,
+                    'pkg',
+                    this.name,
+                    this.version,
+                )}`,
+            );
+
+            if (!res.ok) {
+                this.log.error(
+                    'Unable to retrieve meta information for package',
+                );
+                switch (res.status) {
+                    case 400:
+                        this.log.warn(
+                            'Client attempted to send an invalid URL parameter',
+                        );
+                        break;
+                    case 401:
+                        this.log.warn('Client unauthorized with server');
+                        break;
+                    case 404:
+                        this.log.warn(
+                            'The server was unable to locate the required resource',
+                        );
+                        break;
+                    default:
+                        this.log.warn(`Server failed: ${await res.text()}`);
+                }
+
+                return false;
+            }
+
+            this.log.info(await res.json());
+        } catch (err) {
+            this.log.error('Unable to retrieve meta information for package');
+            this.log.warn(err.message);
+            return false;
+        }
+
+        return true;
+    }
+};

--- a/classes/publish/app.js
+++ b/classes/publish/app.js
@@ -109,16 +109,17 @@ module.exports = class PublishApp {
         try {
             const maps = this.map.map(m =>
                 fetch(m).then(r => {
-                    if (r.status === 404) {
-                        throw new Error(
-                            'Import map could not be found on server',
-                        );
-                    } else if (r.status >= 400 && r.status < 500) {
-                        throw new Error('Server rejected client request');
-                    } else if (r.status >= 500) {
-                        throw new Error('Server error');
-                    } else {
-                        return r.json();
+                    switch (true) {
+                        case r.status === 404:
+                            throw new Error(
+                                'Import map could not be found on server',
+                            );
+                        case r.status >= 400 && r.status < 500:
+                            throw new Error('Server rejected client request');
+                        case r.status >= 500:
+                            throw new Error('Server error');
+                        default:
+                            return r.json();
                     }
                 }),
             );

--- a/classes/publish/dependency.js
+++ b/classes/publish/dependency.js
@@ -115,16 +115,17 @@ module.exports = class PublishDependency {
         try {
             const maps = this.map.map(m =>
                 fetch(m).then(r => {
-                    if (r.status === 404) {
-                        throw new Error(
-                            'Import map could not be found on server',
-                        );
-                    } else if (r.status >= 400 && r.status < 500) {
-                        throw new Error('Server rejected client request');
-                    } else if (r.status >= 500) {
-                        throw new Error('Server error');
-                    } else {
-                        return r.json();
+                    switch (true) {
+                        case r.status === 404:
+                            throw new Error(
+                                'Import map could not be found on server',
+                            );
+                        case r.status >= 400 && r.status < 500:
+                            throw new Error('Server rejected client request');
+                        case r.status >= 500:
+                            throw new Error('Server error');
+                        default:
+                            return r.json();
                     }
                 }),
             );

--- a/classes/publish/dependency.js
+++ b/classes/publish/dependency.js
@@ -14,9 +14,10 @@ const resolve = require('rollup-plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
 const esmImportToUrl = require('rollup-plugin-esm-import-to-url');
 const { execSync } = require('child_process');
-const { writeFileSync } = require('fs');
+const { writeFileSync, existsSync } = require('fs');
 const { join, dirname, parse } = require('path');
 const { validators } = require('@asset-pipe/common');
+const rimraf = require('rimraf');
 const { sendCommand } = require('../../utils');
 
 module.exports = class PublishDependency {
@@ -38,7 +39,7 @@ module.exports = class PublishDependency {
         this.version = version;
         this.map = map;
         this.dryRun = dryRun;
-        this.path = join(tempDir, `publish-${name}-${version}`);
+        this.path = join(tempDir, `publish-${name}-${version}-${Date.now()}`);
     }
 
     async run() {
@@ -101,20 +102,41 @@ module.exports = class PublishDependency {
         } catch (err) {
             this.log.error('Unable to create package json in temp directory');
             this.log.warn(err.message);
+
+            this.log.debug('Cleaning up');
+            if (existsSync(this.path)) {
+                rimraf.sync(this.path);
+            }
+
             return false;
         }
 
         this.log.debug('Loading import map file from server');
         try {
-            const maps = this.map.map(m => fetch(m).then(r => r.json()));
+            const maps = this.map.map(m =>
+                fetch(m).then(r => {
+                    if (r.status === 404) {
+                        throw new Error(
+                            'Import map could not be found on server',
+                        );
+                    } else if (r.status >= 400 && r.status < 500) {
+                        throw new Error('Server rejected client request');
+                    } else if (r.status >= 500) {
+                        throw new Error('Server error');
+                    } else {
+                        return r.json();
+                    }
+                }),
+            );
             const results = await Promise.all(maps);
             const dependencies = results.map(r => r.imports);
             this.importMap = {
                 imports: Object.assign({}, ...dependencies),
             };
         } catch (err) {
-            this.log.warn('Unable to load import map file from server');
-            this.log.warn(err.message);
+            this.log.warn(
+                `Unable to load import map file from server: ${err.message}`,
+            );
         }
 
         this.log.debug('Running npm install in temp directory');
@@ -125,6 +147,12 @@ module.exports = class PublishDependency {
                 'Unable to complete npm install operation, is the supplied module version correct?',
             );
             this.log.warn(err.message);
+
+            this.log.debug('Cleaning up');
+            if (existsSync(this.path)) {
+                rimraf.sync(this.path);
+            }
+
             return false;
         }
 
@@ -140,6 +168,12 @@ module.exports = class PublishDependency {
         } catch (err) {
             this.log.error('Unable to load package meta information');
             this.log.warn(err.message);
+
+            this.log.debug('Cleaning up');
+            if (existsSync(this.path)) {
+                rimraf.sync(this.path);
+            }
+
             return false;
         }
 
@@ -190,6 +224,12 @@ module.exports = class PublishDependency {
         } catch (err) {
             this.log.error('Unable to complete bundle operation');
             this.log.warn(err.message);
+
+            this.log.debug('Cleaning up');
+            if (existsSync(this.path)) {
+                rimraf.sync(this.path);
+            }
+
             return false;
         }
 
@@ -208,6 +248,12 @@ module.exports = class PublishDependency {
         } catch (err) {
             this.log.error('Unable to create zip file');
             this.log.warn(err.message);
+
+            this.log.debug('Cleaning up');
+            if (existsSync(this.path)) {
+                rimraf.sync(this.path);
+            }
+
             return false;
         }
 
@@ -264,7 +310,18 @@ module.exports = class PublishDependency {
                 default:
                     this.log.warn('Server failed');
             }
+
+            this.log.debug('Cleaning up');
+            if (existsSync(this.path)) {
+                rimraf.sync(this.path);
+            }
+
             return false;
+        }
+
+        this.log.debug('Cleaning up');
+        if (existsSync(this.path)) {
+            rimraf.sync(this.path);
         }
 
         this.log.info(

--- a/commands/meta.js
+++ b/commands/meta.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const ora = require('ora');
+const { readFileSync } = require('fs');
+const Meta = require('../classes/meta');
+const { resolvePath, logger } = require('../utils');
+
+exports.command = 'meta <name> <version>';
+
+exports.aliases = ['m', 'show'];
+
+exports.describe = `Retrieve meta information about a package`;
+
+exports.builder = yargs => {
+    const assetsPath = resolvePath('./assets.json').pathname;
+    const assets = JSON.parse(readFileSync(assetsPath));
+
+    yargs
+        .positional('name', {
+            describe:
+                'Name matching either package or import map name depending on type given',
+            type: 'string',
+        })
+        .positional('version', {
+            describe:
+                'Version matching either package or import map version depending on type given',
+            type: 'string',
+        });
+
+    yargs.options({
+        server: {
+            alias: 's',
+            describe: 'Specify location of asset server.',
+            default: assets.server || '',
+        },
+        org: {
+            alias: 'o',
+            describe: 'Provide the organisation context for the command.',
+            default: assets.organisation || '',
+        },
+        debug: {
+            describe: 'Logs additional messages',
+            default: false,
+            type: 'boolean',
+        },
+    });
+};
+
+exports.handler = async argv => {
+    const spinner = ora().start('working...');
+    let success = false;
+    const { debug } = argv;
+
+    try {
+        success = await new Meta({
+            logger: logger(spinner, debug),
+            ...argv,
+        }).run();
+    } catch (err) {
+        logger.warn(err.message);
+    }
+
+    if (success) {
+        spinner.text = '';
+        spinner.stopAndPersist();
+    } else {
+        spinner.text = '';
+        spinner.stopAndPersist();
+        process.exit(1);
+    }
+};

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rimraf": "^3.0.0"
   },
   "devDependencies": {
-    "@asset-pipe/core": "^1.0.0-alpha.2",
+    "@asset-pipe/core": "^1.0.0-alpha.3",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "tar": "^4.4.11",
     "temp-dir": "^2.0.0",
     "rollup-plugin-babel": "^4.3.3",
-    "yargs": "^13.2.4"
+    "yargs": "^13.2.4",
+    "rimraf": "^3.0.0"
   },
   "devDependencies": {
     "@asset-pipe/core": "^1.0.0-alpha.2",

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -15,6 +15,11 @@ test('Initializing a new assets.json file', async t => {
         debug: true,
     }).run();
 
+    // eslint-disable-next-line no-console
+    console.log('join dir:', join(__dirname, 'tmp'));
+    // eslint-disable-next-line no-console
+    console.log('join dir and file', join(__dirname, 'tmp', 'assets.json'));
+
     const assets = JSON.parse(
         readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -15,11 +15,6 @@ test('Initializing a new assets.json file', async t => {
         debug: true,
     }).run();
 
-    // eslint-disable-next-line no-console
-    console.log('join dir:', join(__dirname, 'tmp'));
-    // eslint-disable-next-line no-console
-    console.log('join dir and file', join(__dirname, 'tmp', 'assets.json'));
-
     const assets = JSON.parse(
         readFileSync(join(__dirname, 'tmp', 'assets.json')),
     );

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -10,8 +10,10 @@ const logger = (spinner, debug = false) => ({
     },
     info(message) {
         if (typeof message !== 'string') {
+            // eslint-disable-next-line no-param-reassign
             spinner.text = '';
             spinner.stopAndPersist();
+            // eslint-disable-next-line no-console
             console.log(message);
             spinner.start();
         } else {

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -9,7 +9,14 @@ const logger = (spinner, debug = false) => ({
         spinner.warn(message).start();
     },
     info(message) {
-        spinner.succeed(message).start();
+        if (typeof message !== 'string') {
+            spinner.text = '';
+            spinner.stopAndPersist();
+            console.log(message);
+            spinner.start();
+        } else {
+            spinner.succeed(message).start();
+        }
     },
     debug(message) {
         if (debug) spinner.info(message).start();


### PR DESCRIPTION
I noticed an issue where the node_modules in the temp dir had gotten corrupted or otherwise disturbed and it was no longer possible to get things working again without going into the temp folder and clearing things out manually so I thought it would be better to use a different random dir for each build and clean it up afterwards